### PR TITLE
[#40] Updates `hack` function to support varying numbers of parent Item Sheet classes

### DIFF
--- a/src/scripts/magicItemtab.js
+++ b/src/scripts/magicItemtab.js
@@ -71,9 +71,16 @@ export class MagicItemTab {
 
   hack(app) {
     let tab = this;
-    app.setPosition = function (position = {}) {
+    app.setPosition = function(position = {}) {
       position.height = tab.isActive() && !position.height ? "auto" : position.height;
-      return this.__proto__.__proto__.setPosition.apply(this, [position]);
+      let that = this;
+      for (let i = 0; i < 100; i++) {
+        if (that.constructor.name === ItemSheet.name) {
+          break;
+        }
+        that = Object.getPrototypeOf(that);
+      }
+      return that.setPosition.apply(this, [position]);
     };
   }
 


### PR DESCRIPTION
#40 

Updated `hack` function to crawl up a varying number of prototypes (up to 100 prototypal ancestors; excessive on purpose), to find the correct `ItemSheet` class.

This change supports sheets like Tidy 5e and the Tidy 5e Alpha rewrite, which have a different number of parent classes than the default sheets.

It resolves the issue of scroll being reset when making item sheet changes.