### PR TITLE
50 feature dnd 30 compatibility - Add spell tables back in

### DIFF
--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -109,5 +109,8 @@
 
   "MAGICITEMS.WarnNoActor": "You have no controlled actor, select an actor and retry.",
   "MAGICITEMS.WarnNoMagicItem": "Your controlled Actor does not have an item named ",
-  "MAGICITEMS.WarnNoMagicItemSpell": "Your controlled Actor does not have a spell/feat named "
+  "MAGICITEMS.WarnNoMagicItemSpell": "Your controlled Actor does not have a spell/feat named ",
+
+  "MAGICITEMS.SpellUses": "Uses",
+  "MAGICITEMS.RandomResult": "Random Result"
 }

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -113,6 +113,5 @@
   "MAGICITEMS.WarnNoMagicItem": "Your controlled Actor does not have an item named ",
   "MAGICITEMS.WarnNoMagicItemSpell": "Your controlled Actor does not have a spell/feat named ",
 
-  "MAGICITEMS.SpellUses": "Uses",
   "MAGICITEMS.RandomResult": "Random Result"
 }

--- a/src/scripts/magic-item-entry/MagicItemTable.js
+++ b/src/scripts/magic-item-entry/MagicItemTable.js
@@ -36,6 +36,13 @@ export class MagicItemTable extends AbstractMagicItemEntry {
   }
 
   serializeData() {
-    return {};
+    return {
+      consumption: this.consumption,
+      id: this.id,
+      uuid: this.uuid,
+      img: this.img,
+      name: this.name,
+      pack: this.pack,
+    };
   }
 }

--- a/src/scripts/magic-item/MagicItem.js
+++ b/src/scripts/magic-item/MagicItem.js
@@ -248,9 +248,7 @@ export class MagicItem {
   }
 
   get tableAsSpells() {
-    const tables = this.tablesByUsage(MAGICITEMS.TABLE_USAGE_AS_SPELL);
-    if (tables.length > 0) console.log(tables);
-    return tables;
+    return this.tablesByUsage(MAGICITEMS.TABLE_USAGE_AS_SPELL);
   }
 
   get tableAsFeats() {

--- a/src/scripts/magic-item/MagicItem.js
+++ b/src/scripts/magic-item/MagicItem.js
@@ -112,7 +112,7 @@ export class MagicItem {
 
   serializeEntries(entries, trash) {
     let data = {};
-    entries.forEach((spell, idx) => (data["" + idx] = spell.serializeData()));
+    entries.forEach((entry, idx) => (data["" + idx] = entry.serializeData()));
     trash.forEach((index) => (data["-=" + index] = null));
     return data;
   }
@@ -248,7 +248,9 @@ export class MagicItem {
   }
 
   get tableAsSpells() {
-    return this.tablesByUsage(MAGICITEMS.TABLE_USAGE_AS_SPELL);
+    const tables = this.tablesByUsage(MAGICITEMS.TABLE_USAGE_AS_SPELL);
+    if (tables.length > 0) console.log(tables);
+    return tables;
   }
 
   get tableAsFeats() {

--- a/src/templates/magic-item-spell-sheet-v2.hbs
+++ b/src/templates/magic-item-spell-sheet-v2.hbs
@@ -24,7 +24,7 @@
       {{/if}}
       {{#if chargesPerSpell}}
       <div class="item-header spell-slots">
-        Uses
+        {{localize "MAGICITEMS.SpellUses"}}
       </div>
       {{/if}}
       <div class="item-header spell-rechargeable">{{rechargeableLabel}}</div>
@@ -72,13 +72,48 @@
           {{spell.uses}} / {{../charges}}
           {{/if}}
         </div>
-        <div class="item-detail spell-rechargeable">-</div>
+        {{else}}
+        <div class="item-detail spell-slots">-</div>
         {{/if}}
+        <div class="item-detail spell-rechargeable">-</div>
         <div class="item-detail spell-level">{{spell.level}}</div>
         <div class="item-detail spell-consumption">{{spell.consumption}}</div>
         <div class="item-detail spell-upcast">{{spell.canUpcastLabel}}</div>
       </li>
       {{/each}}
+      {{#if hasTableAsSpells}} {{#each tableAsSpells as |table|}}
+      <li class="item magic-item" data-magic-item-id="{{../id}}" data-item-id="{{table.id}}" draggable="true">
+        <div class="item-name item-action item-tooltip rollable" role="button" aria-label="{{spell.displayName}}">
+          <img class="item-image gold-icon magic-item-image" src="{{table.img}}" alt="{{table.name}}">
+          <div class="name name-stacked">
+            <span class="title">{{ table.displayName }}</span>
+            <span class="subtitle">{{localize "MAGICITEMS.RandomResult"}}</span>
+          </div>
+        </div>
+        {{#if ../chargesPerSpell}}
+        <div class="item-detail spell-slots">
+          {{#if ../sheetEditable}}
+          <input
+            data-item-id="magicitems.{{../id}}.{{table.id}}.uses"
+            type="text"
+            value="{{table.uses}}"
+            placeholder="0"
+          />
+          <span class="sep"> / </span>
+          <input type="text" value="{{../charges}}" placeholder="0" />
+          {{else}}
+          {{spell.uses}} / {{../charges}}
+          {{/if}}
+        </div>
+        {{else}}
+        <div class="item-detail spell-slots">-</div>
+        {{/if}}
+        <div class="item-detail spell-rechargeable">-</div>
+        <div class="item-detail spell-level">-</div>
+        <div class="item-detail spell-consumption">{{table.consumption}}</div>
+        <div class="item-detail spell-upcast">-</div>
+      </li>
+      {{/each}} {{/if}}
     </ol>
   </div>
   {{/if}} {{/each}}


### PR DESCRIPTION
Figured out spell tables, I hadn't realized you could use Rollable Tables as items in a Magic Item. Anyways, got it working for tables as spells, although without any useful rich tooltip - honestly not sure what to put in there, perhaps you might have an idea?