### PR TITLE
Fix for new Tidy Sheet not being ready at sheet type check

### DIFF
--- a/src/scripts/magicitemactor.js
+++ b/src/scripts/magicitemactor.js
@@ -39,7 +39,6 @@ export class MagicItemActor {
     this.listening = true;
     this.instrument();
     this.buildItems();
-    this.isUsingNew5eSheet = this.actor?.sheet && MagicItemHelpers.isUsingNew5eSheet(this.actor.sheet);
   }
 
   /**
@@ -65,13 +64,6 @@ export class MagicItemActor {
     this.actor.getOwnedItem = this.getOwnedItem(this.actor.getOwnedItem, this);
     this.actor.shortRest = this.shortRest(this.actor.shortRest, this);
     this.actor.longRest = this.longRest(this.actor.longRest, this);
-  }
-
-  /**
-   * Updates the property isUsingNew5eSheet with correct values.
-   */
-  updateItemSheetOnActor() {
-    this.isUsingNew5eSheet = this.actor?.sheet && MagicItemHelpers.isUsingNew5eSheet(this.actor.sheet);
   }
 
   /**
@@ -183,6 +175,13 @@ export class MagicItemActor {
    */
   get visibleItems() {
     return this.items.filter((item) => item.visible);
+  }
+
+  /**
+   *
+   */
+  get isUsingNew5eSheet() {
+    return this.actor?.sheet && MagicItemHelpers.isUsingNew5eSheet(this.actor?.sheet);
   }
 
   /**

--- a/src/scripts/magicitemsheet.js
+++ b/src/scripts/magicitemsheet.js
@@ -57,7 +57,6 @@ export class MagicItemSheet {
    */
   async render() {
     Logger.log(`IsUsingNew5eSheet: ${this.actor.isUsingNew5eSheet}`);
-    this.actor.updateItemSheetOnActor();
     if (!this.actor.isUsingNew5eSheet) {
       if (this.actor.hasItemsFeats()) {
         await this.renderTemplate(


### PR DESCRIPTION
I noticed Tidy5e was blowing up with the latest release and the culprit appears to be the sheet check property - it was causing Tidy to error because it wasn't ready yet. I've fixed it by changing it to a getter which also resolves the other issue with switching back and forth between sheets.