### PR TITLE
#99 babele packs initializing too slow fix

### DIFF
--- a/src/scripts/magic-item-helpers.js
+++ b/src/scripts/magic-item-helpers.js
@@ -49,7 +49,7 @@ export class MagicItemHelpers {
   }
 
   static getEntityNameCompendiumWithBabele(packToCheck, nameToCheck) {
-    if (game.modules.get("babele")?.active) {
+    if (game.modules.get("babele")?.active && game.babele?.packs !== undefined) {
       if (packToCheck !== "world" && game.babele?.isTranslated(packToCheck)) {
         return game.babele.translateField("name", packToCheck, { name: nameToCheck });
       } else {


### PR DESCRIPTION
The packs object from babele has been initializing too slow - if you check for game.babele?.packs !== undefined, the error stops popping